### PR TITLE
Add advanced GUI with categories and recipe editing

### DIFF
--- a/src/main/java/fr/jachou/moreItems/commands/MoreItemsCommand.java
+++ b/src/main/java/fr/jachou/moreItems/commands/MoreItemsCommand.java
@@ -2,7 +2,7 @@ package fr.jachou.moreItems.commands;
 
 import fr.jachou.moreItems.managers.ItemManager;
 import fr.jachou.moreItems.items.CustomItem;
-import fr.jachou.moreItems.gui.ManagerGUI;
+import fr.jachou.moreItems.gui.CategoryGUI;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -22,7 +22,7 @@ public class MoreItemsCommand implements CommandExecutor {
         }
 
         if (args.length == 0 || args[0].equalsIgnoreCase("gui")) {
-            ManagerGUI.open(player);
+            CategoryGUI.open(player);
             return true;
         }
         if (args.length < 2 || !args[0].equalsIgnoreCase("get")) {

--- a/src/main/java/fr/jachou/moreItems/gui/Category.java
+++ b/src/main/java/fr/jachou/moreItems/gui/Category.java
@@ -1,0 +1,23 @@
+package fr.jachou.moreItems.gui;
+
+import org.bukkit.ChatColor;
+
+/**
+ * Simple item categories for GUI organisation.
+ */
+public enum Category {
+    ARMOR(ChatColor.AQUA + "Armure"),
+    WEAPON(ChatColor.RED + "Armes"),
+    TOOL(ChatColor.GOLD + "Outils"),
+    UTILITY(ChatColor.GREEN + "Divers");
+
+    private final String display;
+
+    Category(String display) {
+        this.display = display;
+    }
+
+    public String getDisplay() {
+        return display;
+    }
+}

--- a/src/main/java/fr/jachou/moreItems/gui/CategoryGUI.java
+++ b/src/main/java/fr/jachou/moreItems/gui/CategoryGUI.java
@@ -1,0 +1,44 @@
+package fr.jachou.moreItems.gui;
+
+import fr.jachou.moreItems.utils.ItemBuilder;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+
+/**
+ * GUI listing available item categories.
+ */
+public class CategoryGUI {
+    private static final String TITLE = ChatColor.GREEN + "MoreItems";
+
+    public static void open(Player player) {
+        Inventory inv = Bukkit.createInventory(player, 9, TITLE);
+        inv.addItem(ItemBuilder.of(Material.DIAMOND_CHESTPLATE).name(Category.ARMOR.getDisplay()).build());
+        inv.addItem(ItemBuilder.of(Material.DIAMOND_SWORD).name(Category.WEAPON.getDisplay()).build());
+        inv.addItem(ItemBuilder.of(Material.IRON_PICKAXE).name(Category.TOOL.getDisplay()).build());
+        inv.addItem(ItemBuilder.of(Material.BOOK).name(Category.UTILITY.getDisplay()).build());
+        player.openInventory(inv);
+    }
+
+    public static boolean handle(InventoryClickEvent event) {
+        if (!event.getView().getTitle().equals(TITLE)) {
+            return false;
+        }
+        event.setCancelled(true);
+        if (event.getCurrentItem() == null || !event.getCurrentItem().hasItemMeta()) {
+            return true;
+        }
+        String name = ChatColor.stripColor(event.getCurrentItem().getItemMeta().getDisplayName());
+        Player player = (Player) event.getWhoClicked();
+        for (Category cat : Category.values()) {
+            if (cat.getDisplay().equals(ChatColor.GREEN + name) || name.equals(ChatColor.stripColor(cat.getDisplay()))) {
+                ManagerGUI.open(player, cat, 0);
+                break;
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/fr/jachou/moreItems/gui/ItemInfoGUI.java
+++ b/src/main/java/fr/jachou/moreItems/gui/ItemInfoGUI.java
@@ -1,0 +1,52 @@
+package fr.jachou.moreItems.gui;
+
+import fr.jachou.moreItems.items.CustomItem;
+import fr.jachou.moreItems.utils.ItemBuilder;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * GUI displaying information about a custom item.
+ */
+public class ItemInfoGUI {
+    private static final ItemStack RECIPE = ItemBuilder.of(Material.CRAFTING_TABLE).name(ChatColor.YELLOW + "Voir le craft").build();
+    private static final ItemStack EDIT = ItemBuilder.of(Material.ANVIL).name(ChatColor.YELLOW + "Modifier le craft").build();
+    private record Holder(CustomItem item) implements InventoryHolder {
+        @Override
+        public Inventory getInventory() {
+            return null;
+        }
+    }
+
+    public static void open(Player player, CustomItem item) {
+        Inventory inv = Bukkit.createInventory(new Holder(item), 27,
+                ChatColor.GREEN + item.getItem().getItemMeta().getDisplayName());
+        inv.setItem(13, item.getItem());
+        inv.setItem(22, RECIPE);
+        inv.setItem(23, EDIT);
+        player.openInventory(inv);
+    }
+
+    public static boolean handle(InventoryClickEvent event) {
+        if (!(event.getInventory().getHolder() instanceof Holder holder)) {
+            return false;
+        }
+        event.setCancelled(true);
+        Player player = (Player) event.getWhoClicked();
+        if (event.getSlot() == 22) {
+            RecipeGUI.open(player, holder.item());
+            return true;
+        }
+        if (event.getSlot() == 23) {
+            RecipeEditorGUI.open(player, holder.item());
+            return true;
+        }
+        return true;
+    }
+}

--- a/src/main/java/fr/jachou/moreItems/gui/ManagerGUI.java
+++ b/src/main/java/fr/jachou/moreItems/gui/ManagerGUI.java
@@ -2,34 +2,77 @@ package fr.jachou.moreItems.gui;
 
 import fr.jachou.moreItems.managers.ItemManager;
 import fr.jachou.moreItems.items.CustomItem;
+import fr.jachou.moreItems.utils.ItemBuilder;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.List;
 
 /**
- * Simple GUI allowing players to obtain custom items.
+ * Paged GUI showing items from a category.
  */
 public class ManagerGUI {
-    private static final String TITLE = ChatColor.GREEN + "MoreItems";
+    private static final int ITEMS_PER_PAGE = 45;
+    private static final ItemStack NEXT = ItemBuilder.of(Material.ARROW).name(ChatColor.YELLOW + "Suivant").build();
+    private static final ItemStack PREV = ItemBuilder.of(Material.ARROW).name(ChatColor.YELLOW + "Précédent").build();
+    private static final ItemStack BACK = ItemBuilder.of(Material.BARRIER).name(ChatColor.RED + "Retour").build();
 
-    public static void open(Player player) {
-        Inventory inv = Bukkit.createInventory(player, ((ItemManager.all().size() - 1) / 9 + 1) * 9, TITLE);
-        for (CustomItem item : ItemManager.all()) {
-            inv.addItem(item.getItem());
+    private record Holder(Category category, int page) implements InventoryHolder {
+        @Override
+        public Inventory getInventory() {
+            return null;
         }
+    }
+
+    public static void open(Player player, Category category, int page) {
+        List<CustomItem> items = ItemManager.all(category).stream().toList();
+        int maxPage = Math.max(0, (items.size() - 1) / ITEMS_PER_PAGE);
+        if (page < 0) page = 0;
+        if (page > maxPage) page = maxPage;
+        Inventory inv = Bukkit.createInventory(new Holder(category, page), 54,
+                ChatColor.GREEN + "MoreItems - " + category.getDisplay());
+        int start = page * ITEMS_PER_PAGE;
+        for (int i = 0; i < ITEMS_PER_PAGE && start + i < items.size(); i++) {
+            inv.setItem(i, items.get(start + i).getItem());
+        }
+        if (page > 0) inv.setItem(45, PREV);
+        inv.setItem(49, BACK);
+        if (page < maxPage) inv.setItem(53, NEXT);
         player.openInventory(inv);
     }
 
     public static boolean handle(InventoryClickEvent event) {
-        if (event.getView().getTitle().equals(TITLE)) {
-            event.setCancelled(true);
-            if (event.getCurrentItem() != null) {
-                event.getWhoClicked().getInventory().addItem(event.getCurrentItem());
-            }
+        if (!(event.getInventory().getHolder() instanceof Holder holder)) {
+            return false;
+        }
+        event.setCancelled(true);
+        Player player = (Player) event.getWhoClicked();
+        int slot = event.getRawSlot();
+        if (slot == 45 && event.getCurrentItem() != null && event.getCurrentItem().isSimilar(PREV)) {
+            open(player, holder.category(), holder.page() - 1);
             return true;
         }
-        return false;
+        if (slot == 53 && event.getCurrentItem() != null && event.getCurrentItem().isSimilar(NEXT)) {
+            open(player, holder.category(), holder.page() + 1);
+            return true;
+        }
+        if (slot == 49) {
+            CategoryGUI.open(player);
+            return true;
+        }
+        ItemStack clicked = event.getCurrentItem();
+        if (clicked != null) {
+            CustomItem item = ItemManager.fromItemStack(clicked);
+            if (item != null) {
+                ItemInfoGUI.open(player, item);
+            }
+        }
+        return true;
     }
 }

--- a/src/main/java/fr/jachou/moreItems/gui/RecipeEditorGUI.java
+++ b/src/main/java/fr/jachou/moreItems/gui/RecipeEditorGUI.java
@@ -1,0 +1,97 @@
+package fr.jachou.moreItems.gui;
+
+import fr.jachou.moreItems.items.CustomItem;
+import fr.jachou.moreItems.managers.RecipeManager;
+import fr.jachou.moreItems.utils.ItemBuilder;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.RecipeChoice;
+import org.bukkit.inventory.ShapedRecipe;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * GUI used to edit crafting recipes.
+ */
+public class RecipeEditorGUI {
+    private static final ItemStack CONFIRM = ItemBuilder.of(Material.LIME_WOOL).name(ChatColor.GREEN + "Confirmer").build();
+    private static final ItemStack CANCEL = ItemBuilder.of(Material.RED_WOOL).name(ChatColor.RED + "Annuler").build();
+
+    private record Holder(CustomItem item) implements InventoryHolder {
+        @Override
+        public Inventory getInventory() { return null; }
+    }
+
+    public static void open(Player player, CustomItem item) {
+        Inventory inv = Bukkit.createInventory(new Holder(item), 27, ChatColor.GREEN + "Edit Craft");
+        ShapedRecipe recipe = RecipeManager.get(item);
+        if (recipe != null) {
+            String[] shape = recipe.getShape();
+            Map<Character, RecipeChoice> map = recipe.getChoiceMap();
+            for (int r = 0; r < shape.length; r++) {
+                for (int c = 0; c < shape[r].length(); c++) {
+                    char ch = shape[r].charAt(c);
+                    if (ch != ' ' && map.get(ch) != null) {
+                        ItemStack icon = map.get(ch).getItemStack();
+                        inv.setItem(10 + r * 9 + c, icon);
+                    }
+                }
+            }
+        }
+        inv.setItem(22, item.getItem());
+        inv.setItem(24, CONFIRM);
+        inv.setItem(26, CANCEL);
+        player.openInventory(inv);
+    }
+
+    public static boolean handle(InventoryClickEvent event) {
+        if (!(event.getInventory().getHolder() instanceof Holder holder)) {
+            return false;
+        }
+        if (event.getSlot() == 24 || event.getSlot() == 26 || event.getSlot() == 22) {
+            event.setCancelled(true);
+        }
+        if (event.getSlot() == 24) {
+            Inventory inv = event.getInventory();
+            String[] shape = new String[3];
+            Map<Character, ItemStack> items = new HashMap<>();
+            char c = 'A';
+            for (int r = 0; r < 3; r++) {
+                StringBuilder row = new StringBuilder();
+                for (int col = 0; col < 3; col++) {
+                    ItemStack is = inv.getItem(10 + r * 9 + col);
+                    if (is == null || is.getType() == Material.AIR) {
+                        row.append(' ');
+                    } else {
+                        row.append(c);
+                        items.put(c, is.clone());
+                        c++;
+                    }
+                }
+                shape[r] = row.toString();
+            }
+            ShapedRecipe recipe = new ShapedRecipe(holder.item().getKey(), holder.item().getItem());
+            recipe.shape(shape);
+            for (Map.Entry<Character, ItemStack> e : items.entrySet()) {
+                recipe.setIngredient(e.getKey(), new RecipeChoice.ExactChoice(e.getValue()));
+            }
+            RecipeManager.update(holder.item(), recipe);
+            event.getWhoClicked().sendMessage(ChatColor.GREEN + "Recette mise à jour !");
+            ItemInfoGUI.open((Player) event.getWhoClicked(), holder.item());
+            return true;
+        }
+        if (event.getSlot() == 26) {
+            event.setCancelled(true);
+            ItemInfoGUI.open((Player) event.getWhoClicked(), holder.item());
+            return true;
+        }
+        return true;
+    }
+}

--- a/src/main/java/fr/jachou/moreItems/gui/RecipeGUI.java
+++ b/src/main/java/fr/jachou/moreItems/gui/RecipeGUI.java
@@ -1,0 +1,54 @@
+package fr.jachou.moreItems.gui;
+
+import fr.jachou.moreItems.items.CustomItem;
+import fr.jachou.moreItems.managers.RecipeManager;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.InventoryHolder;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.RecipeChoice;
+import org.bukkit.inventory.ShapedRecipe;
+
+import java.util.Map;
+
+/**
+ * Shows the crafting recipe of an item.
+ */
+public class RecipeGUI {
+    private static final String TITLE = ChatColor.GREEN + "Recette";
+    private record Holder(CustomItem item) implements InventoryHolder {
+        @Override
+        public Inventory getInventory() { return null; }
+    }
+
+    public static void open(Player player, CustomItem item) {
+        Inventory inv = Bukkit.createInventory(new Holder(item), 27, TITLE);
+        ShapedRecipe recipe = RecipeManager.get(item);
+        if (recipe != null) {
+            String[] shape = recipe.getShape();
+            Map<Character, RecipeChoice> map = recipe.getChoiceMap();
+            for (int r = 0; r < shape.length; r++) {
+                for (int c = 0; c < shape[r].length(); c++) {
+                    char ch = shape[r].charAt(c);
+                    if (ch != ' ' && map.get(ch) != null) {
+                        ItemStack icon = map.get(ch).getItemStack();
+                        inv.setItem(10 + r * 9 + c, icon);
+                    }
+                }
+            }
+        }
+        inv.setItem(22, item.getItem());
+        player.openInventory(inv);
+    }
+
+    public static boolean handle(InventoryClickEvent event) {
+        if (!(event.getInventory().getHolder() instanceof Holder)) {
+            return false;
+        }
+        event.setCancelled(true);
+        return true;
+    }
+}

--- a/src/main/java/fr/jachou/moreItems/listeners/ManagerGUIListener.java
+++ b/src/main/java/fr/jachou/moreItems/listeners/ManagerGUIListener.java
@@ -1,6 +1,10 @@
 package fr.jachou.moreItems.listeners;
 
+import fr.jachou.moreItems.gui.CategoryGUI;
 import fr.jachou.moreItems.gui.ManagerGUI;
+import fr.jachou.moreItems.gui.ItemInfoGUI;
+import fr.jachou.moreItems.gui.RecipeGUI;
+import fr.jachou.moreItems.gui.RecipeEditorGUI;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -12,6 +16,10 @@ public class ManagerGUIListener implements Listener {
 
     @EventHandler
     public void onClick(InventoryClickEvent event) {
-        ManagerGUI.handle(event);
+        if (CategoryGUI.handle(event)) return;
+        if (ManagerGUI.handle(event)) return;
+        if (ItemInfoGUI.handle(event)) return;
+        if (RecipeGUI.handle(event)) return;
+        if (RecipeEditorGUI.handle(event)) return;
     }
 }

--- a/src/main/java/fr/jachou/moreItems/managers/ItemManager.java
+++ b/src/main/java/fr/jachou/moreItems/managers/ItemManager.java
@@ -2,6 +2,7 @@ package fr.jachou.moreItems.managers;
 
 import fr.jachou.moreItems.items.CustomItem;
 import fr.jachou.moreItems.items.*;
+import fr.jachou.moreItems.gui.Category;
 import org.bukkit.NamespacedKey;
 import org.bukkit.plugin.Plugin;
 
@@ -15,43 +16,65 @@ import java.util.Map;
 public final class ItemManager {
 
     private static final Map<String, CustomItem> ITEMS = new HashMap<>();
+    private static final Map<String, Category> ITEM_CATEGORIES = new HashMap<>();
 
     private ItemManager() {
     }
 
     public static void init(Plugin plugin) {
-        register(new SpeedBoots(plugin));
-        register(new JumpBoots(plugin));
-        register(new FireSword(plugin));
-        register(new TeleportBow(plugin));
-        register(new MagnetPickaxe(plugin));
-        register(new HealthChestplate(plugin));
-        register(new XPHelmet(plugin));
-        register(new FrostWand(plugin));
-        register(new ExplosivePickaxe(plugin));
-        register(new LightningStick(plugin));
-        register(new SandWand(plugin));
-        register(new LeatherPouch(plugin));
-        register(new GrappleArrow(plugin));
-        register(new MasonHammer(plugin));
-        register(new FishingNet(plugin));
-        register(new PocketBell(plugin));
-        register(new SurvivalRation(plugin));
-        register(new DriedApple(plugin));
-        register(new CampfireStick(plugin));
-        register(new ReturnScroll(plugin));
-        register(new IcePop(plugin));
+        register(new SpeedBoots(plugin), Category.ARMOR);
+        register(new JumpBoots(plugin), Category.ARMOR);
+        register(new FireSword(plugin), Category.WEAPON);
+        register(new TeleportBow(plugin), Category.WEAPON);
+        register(new MagnetPickaxe(plugin), Category.TOOL);
+        register(new HealthChestplate(plugin), Category.ARMOR);
+        register(new XPHelmet(plugin), Category.ARMOR);
+        register(new FrostWand(plugin), Category.WEAPON);
+        register(new ExplosivePickaxe(plugin), Category.TOOL);
+        register(new LightningStick(plugin), Category.WEAPON);
+        register(new SandWand(plugin), Category.WEAPON);
+        register(new LeatherPouch(plugin), Category.UTILITY);
+        register(new GrappleArrow(plugin), Category.WEAPON);
+        register(new MasonHammer(plugin), Category.TOOL);
+        register(new FishingNet(plugin), Category.TOOL);
+        register(new PocketBell(plugin), Category.UTILITY);
+        register(new SurvivalRation(plugin), Category.UTILITY);
+        register(new DriedApple(plugin), Category.UTILITY);
+        register(new CampfireStick(plugin), Category.TOOL);
+        register(new ReturnScroll(plugin), Category.UTILITY);
+        register(new IcePop(plugin), Category.UTILITY);
     }
 
-    private static void register(CustomItem item) {
+    private static void register(CustomItem item, Category category) {
         ITEMS.put(item.getKey().getKey(), item);
+        ITEM_CATEGORIES.put(item.getKey().getKey(), category);
     }
 
     public static Collection<CustomItem> all() {
         return ITEMS.values();
     }
 
+    public static Collection<CustomItem> all(Category category) {
+        return ITEMS.values().stream()
+                .filter(i -> ITEM_CATEGORIES.getOrDefault(i.getKey().getKey(), Category.UTILITY) == category)
+                .toList();
+    }
+
+    public static Category getCategory(CustomItem item) {
+        return ITEM_CATEGORIES.getOrDefault(item.getKey().getKey(), Category.UTILITY);
+    }
+
     public static CustomItem byKey(NamespacedKey key) {
         return ITEMS.get(key.getKey());
+    }
+
+    public static CustomItem fromItemStack(org.bukkit.inventory.ItemStack stack) {
+        if (stack == null) return null;
+        for (CustomItem item : ITEMS.values()) {
+            if (item.getItem().isSimilar(stack)) {
+                return item;
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/fr/jachou/moreItems/managers/RecipeManager.java
+++ b/src/main/java/fr/jachou/moreItems/managers/RecipeManager.java
@@ -1,23 +1,46 @@
 package fr.jachou.moreItems.managers;
 
 import fr.jachou.moreItems.items.CustomItem;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.RecipeChoice;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.plugin.Plugin;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Registers custom crafting recipes for all items.
  */
 public final class RecipeManager {
 
+    private static final Map<NamespacedKey, ShapedRecipe> RECIPES = new HashMap<>();
+    private static Plugin plugin;
+
     private RecipeManager() {
     }
 
-    public static void init(Plugin plugin) {
+    public static void init(Plugin pl) {
+        plugin = pl;
         for (CustomItem item : ItemManager.all()) {
             ShapedRecipe recipe = item.getRecipe();
             if (recipe != null) {
-                plugin.getServer().addRecipe(recipe);
+                register(item, recipe);
             }
         }
+    }
+
+    private static void register(CustomItem item, ShapedRecipe recipe) {
+        RECIPES.put(item.getKey(), recipe);
+        plugin.getServer().addRecipe(recipe);
+    }
+
+    public static ShapedRecipe get(CustomItem item) {
+        return RECIPES.get(item.getKey());
+    }
+
+    public static void update(CustomItem item, ShapedRecipe recipe) {
+        plugin.getServer().removeRecipe(item.getKey());
+        register(item, recipe);
     }
 }


### PR DESCRIPTION
## Summary
- create a `Category` enum to group items
- add `CategoryGUI`, `ManagerGUI`, `ItemInfoGUI`, `RecipeGUI` and `RecipeEditorGUI`
- register item categories and expose extra helpers in `ItemManager`
- store recipes dynamically in `RecipeManager`
- route clicks in `ManagerGUIListener`
- command `/moreitems gui` now opens the category menu

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q -DskipTests package` *(fails: Could not transfer artifact org.apache.maven.plugins:maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68585dbe724c832ebdedb5dbcffe7589