### PR TITLE
Fix recipe GUI and localization

### DIFF
--- a/src/main/java/fr/jachou/moreItems/gui/Category.java
+++ b/src/main/java/fr/jachou/moreItems/gui/Category.java
@@ -1,23 +1,23 @@
 package fr.jachou.moreItems.gui;
 
-import org.bukkit.ChatColor;
+import fr.jachou.moreItems.MoreItems;
 
 /**
  * Simple item categories for GUI organisation.
  */
 public enum Category {
-    ARMOR(ChatColor.AQUA + "Armure"),
-    WEAPON(ChatColor.RED + "Armes"),
-    TOOL(ChatColor.GOLD + "Outils"),
-    UTILITY(ChatColor.GREEN + "Divers");
+    ARMOR("categories.ARMOR"),
+    WEAPON("categories.WEAPON"),
+    TOOL("categories.TOOL"),
+    UTILITY("categories.UTILITY");
 
-    private final String display;
+    private final String key;
 
-    Category(String display) {
-        this.display = display;
+    Category(String key) {
+        this.key = key;
     }
 
     public String getDisplay() {
-        return display;
+        return MoreItems.getInstance().getLang().get(key);
     }
 }

--- a/src/main/java/fr/jachou/moreItems/gui/ItemInfoGUI.java
+++ b/src/main/java/fr/jachou/moreItems/gui/ItemInfoGUI.java
@@ -39,6 +39,11 @@ public class ItemInfoGUI {
         }
         event.setCancelled(true);
         Player player = (Player) event.getWhoClicked();
+        if (event.getSlot() == 13) {
+            player.getInventory().addItem(holder.item().getItem());
+            player.sendMessage(ChatColor.GREEN + "Item given!");
+            return true;
+        }
         if (event.getSlot() == 22) {
             RecipeGUI.open(player, holder.item());
             return true;

--- a/src/main/java/fr/jachou/moreItems/gui/RecipeEditorGUI.java
+++ b/src/main/java/fr/jachou/moreItems/gui/RecipeEditorGUI.java
@@ -30,7 +30,7 @@ public class RecipeEditorGUI {
     }
 
     public static void open(Player player, CustomItem item) {
-        Inventory inv = Bukkit.createInventory(new Holder(item), 27, ChatColor.GREEN + "Edit Craft");
+        Inventory inv = Bukkit.createInventory(new Holder(item), 36, ChatColor.GREEN + "Edit Craft");
         ShapedRecipe recipe = RecipeManager.get(item);
         if (recipe != null) {
             String[] shape = recipe.getShape();

--- a/src/main/java/fr/jachou/moreItems/gui/RecipeGUI.java
+++ b/src/main/java/fr/jachou/moreItems/gui/RecipeGUI.java
@@ -25,7 +25,7 @@ public class RecipeGUI {
     }
 
     public static void open(Player player, CustomItem item) {
-        Inventory inv = Bukkit.createInventory(new Holder(item), 27, TITLE);
+        Inventory inv = Bukkit.createInventory(new Holder(item), 36, TITLE);
         ShapedRecipe recipe = RecipeManager.get(item);
         if (recipe != null) {
             String[] shape = recipe.getShape();

--- a/src/main/resources/lang/en.yml
+++ b/src/main/resources/lang/en.yml
@@ -64,3 +64,8 @@ items:
   icePop:
     name: "§bIce Pop"
     description: "§7Heals but slows you."
+categories:
+  ARMOR: "§bArmor"
+  WEAPON: "§cWeapons"
+  TOOL: "§6Tools"
+  UTILITY: "§aUtility"


### PR DESCRIPTION
## Summary
- support language file for category names
- increase recipe editor GUI size to prevent index error
- add ability to obtain item from item info GUI
- expand recipe GUI to 36 slots
- document category strings in `en.yml`

## Testing
- `mvn -q test` *(fails: Plugin resolution exception)*
- `mvn -q -DskipTests package` *(fails: Plugin resolution exception)*

------
https://chatgpt.com/codex/tasks/task_e_6858684d5f5c832e8812bb9fc33334aa