### PR TITLE
Add new utility and tool items

### DIFF
--- a/src/main/java/fr/jachou/moreItems/items/AlchemyBackpack.java
+++ b/src/main/java/fr/jachou/moreItems/items/AlchemyBackpack.java
@@ -1,0 +1,52 @@
+package fr.jachou.moreItems.items;
+
+import fr.jachou.moreItems.MoreItems;
+import fr.jachou.moreItems.utils.ItemBuilder;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.Plugin;
+
+import java.util.Collections;
+
+/**
+ * Simple backpack to store potions.
+ */
+public class AlchemyBackpack implements CustomItem {
+    public static final String KEY_ID = "alchemy_backpack";
+
+    private final NamespacedKey key;
+    private final ItemStack item;
+    private final ShapedRecipe recipe;
+
+    public AlchemyBackpack(Plugin plugin) {
+        this.key = new NamespacedKey(plugin, KEY_ID);
+        this.item = ItemBuilder.of(Material.SHULKER_BOX)
+                .name(MoreItems.getInstance().getLang().get("items.alchemyBackpack.name"))
+                .lore(Collections.singletonList(MoreItems.getInstance().getLang().get("items.alchemyBackpack.description")))
+                .persistentData(key, PersistentDataType.STRING, "abag")
+                .build();
+
+        this.recipe = new ShapedRecipe(key, item);
+        recipe.shape("LLL", "LBL", "LLL");
+        recipe.setIngredient('L', Material.LEATHER);
+        recipe.setIngredient('B', Material.BREWING_STAND);
+    }
+
+    @Override
+    public NamespacedKey getKey() {
+        return key;
+    }
+
+    @Override
+    public ItemStack getItem() {
+        return item.clone();
+    }
+
+    @Override
+    public ShapedRecipe getRecipe() {
+        return recipe;
+    }
+}

--- a/src/main/java/fr/jachou/moreItems/items/InvisibilityHood.java
+++ b/src/main/java/fr/jachou/moreItems/items/InvisibilityHood.java
@@ -1,0 +1,51 @@
+package fr.jachou.moreItems.items;
+
+import fr.jachou.moreItems.MoreItems;
+import fr.jachou.moreItems.utils.ItemBuilder;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.Plugin;
+
+import java.util.Collections;
+
+/**
+ * Hood granting invisibility while worn.
+ */
+public class InvisibilityHood implements CustomItem {
+    public static final String KEY_ID = "invisibility_hood";
+
+    private final NamespacedKey key;
+    private final ItemStack item;
+    private final ShapedRecipe recipe;
+
+    public InvisibilityHood(Plugin plugin) {
+        this.key = new NamespacedKey(plugin, KEY_ID);
+        this.item = ItemBuilder.of(Material.LEATHER_HELMET)
+                .name(MoreItems.getInstance().getLang().get("items.invisibilityHood.name"))
+                .lore(Collections.singletonList(MoreItems.getInstance().getLang().get("items.invisibilityHood.description")))
+                .persistentData(key, PersistentDataType.STRING, "hood")
+                .build();
+
+        this.recipe = new ShapedRecipe(key, item);
+        recipe.shape("LLL", "L L", "   ");
+        recipe.setIngredient('L', Material.LEATHER);
+    }
+
+    @Override
+    public NamespacedKey getKey() {
+        return key;
+    }
+
+    @Override
+    public ItemStack getItem() {
+        return item.clone();
+    }
+
+    @Override
+    public ShapedRecipe getRecipe() {
+        return recipe;
+    }
+}

--- a/src/main/java/fr/jachou/moreItems/items/PickupMagnet.java
+++ b/src/main/java/fr/jachou/moreItems/items/PickupMagnet.java
@@ -1,0 +1,53 @@
+package fr.jachou.moreItems.items;
+
+import fr.jachou.moreItems.MoreItems;
+import fr.jachou.moreItems.utils.ItemBuilder;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.Plugin;
+
+import java.util.Collections;
+
+/**
+ * Magnet that collects nearby dropped items on use.
+ */
+public class PickupMagnet implements CustomItem {
+    public static final String KEY_ID = "pickup_magnet";
+
+    private final NamespacedKey key;
+    private final ItemStack item;
+    private final ShapedRecipe recipe;
+
+    public PickupMagnet(Plugin plugin) {
+        this.key = new NamespacedKey(plugin, KEY_ID);
+        this.item = ItemBuilder.of(Material.COMPASS)
+                .name(MoreItems.getInstance().getLang().get("items.pickupMagnet.name"))
+                .lore(Collections.singletonList(MoreItems.getInstance().getLang().get("items.pickupMagnet.description")))
+                .persistentData(key, PersistentDataType.STRING, "magnet")
+                .build();
+
+        this.recipe = new ShapedRecipe(key, item);
+        recipe.shape("IRI", "RER", "IRI");
+        recipe.setIngredient('I', Material.IRON_INGOT);
+        recipe.setIngredient('R', Material.REDSTONE);
+        recipe.setIngredient('E', Material.ENDER_PEARL);
+    }
+
+    @Override
+    public NamespacedKey getKey() {
+        return key;
+    }
+
+    @Override
+    public ItemStack getItem() {
+        return item.clone();
+    }
+
+    @Override
+    public ShapedRecipe getRecipe() {
+        return recipe;
+    }
+}

--- a/src/main/java/fr/jachou/moreItems/items/PortableAnvil.java
+++ b/src/main/java/fr/jachou/moreItems/items/PortableAnvil.java
@@ -1,0 +1,52 @@
+package fr.jachou.moreItems.items;
+
+import fr.jachou.moreItems.MoreItems;
+import fr.jachou.moreItems.utils.ItemBuilder;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.Plugin;
+
+import java.util.Collections;
+
+/**
+ * Lightweight anvil usable from inventory.
+ */
+public class PortableAnvil implements CustomItem {
+    public static final String KEY_ID = "portable_anvil";
+
+    private final NamespacedKey key;
+    private final ItemStack item;
+    private final ShapedRecipe recipe;
+
+    public PortableAnvil(Plugin plugin) {
+        this.key = new NamespacedKey(plugin, KEY_ID);
+        this.item = ItemBuilder.of(Material.ANVIL)
+                .name(MoreItems.getInstance().getLang().get("items.portableAnvil.name"))
+                .lore(Collections.singletonList(MoreItems.getInstance().getLang().get("items.portableAnvil.description")))
+                .persistentData(key, PersistentDataType.STRING, "panvil")
+                .build();
+
+        this.recipe = new ShapedRecipe(key, item);
+        recipe.shape("III", "IAI", "III");
+        recipe.setIngredient('I', Material.IRON_INGOT);
+        recipe.setIngredient('A', Material.ANVIL);
+    }
+
+    @Override
+    public NamespacedKey getKey() {
+        return key;
+    }
+
+    @Override
+    public ItemStack getItem() {
+        return item.clone();
+    }
+
+    @Override
+    public ShapedRecipe getRecipe() {
+        return recipe;
+    }
+}

--- a/src/main/java/fr/jachou/moreItems/items/PortableFurnace.java
+++ b/src/main/java/fr/jachou/moreItems/items/PortableFurnace.java
@@ -1,0 +1,52 @@
+package fr.jachou.moreItems.items;
+
+import fr.jachou.moreItems.MoreItems;
+import fr.jachou.moreItems.utils.ItemBuilder;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.Plugin;
+
+import java.util.Collections;
+
+/**
+ * Portable furnace opening a furnace interface on use.
+ */
+public class PortableFurnace implements CustomItem {
+    public static final String KEY_ID = "portable_furnace";
+
+    private final NamespacedKey key;
+    private final ItemStack item;
+    private final ShapedRecipe recipe;
+
+    public PortableFurnace(Plugin plugin) {
+        this.key = new NamespacedKey(plugin, KEY_ID);
+        this.item = ItemBuilder.of(Material.FURNACE)
+                .name(MoreItems.getInstance().getLang().get("items.portableFurnace.name"))
+                .lore(Collections.singletonList(MoreItems.getInstance().getLang().get("items.portableFurnace.description")))
+                .persistentData(key, PersistentDataType.STRING, "pfurnace")
+                .build();
+
+        this.recipe = new ShapedRecipe(key, item);
+        recipe.shape("III", "IFI", "III");
+        recipe.setIngredient('I', Material.IRON_INGOT);
+        recipe.setIngredient('F', Material.FURNACE);
+    }
+
+    @Override
+    public NamespacedKey getKey() {
+        return key;
+    }
+
+    @Override
+    public ItemStack getItem() {
+        return item.clone();
+    }
+
+    @Override
+    public ShapedRecipe getRecipe() {
+        return recipe;
+    }
+}

--- a/src/main/java/fr/jachou/moreItems/items/PortalBook.java
+++ b/src/main/java/fr/jachou/moreItems/items/PortalBook.java
@@ -1,0 +1,52 @@
+package fr.jachou.moreItems.items;
+
+import fr.jachou.moreItems.MoreItems;
+import fr.jachou.moreItems.utils.ItemBuilder;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.Plugin;
+
+import java.util.Collections;
+
+/**
+ * Book used to set anchors and teleport between them.
+ */
+public class PortalBook implements CustomItem {
+    public static final String KEY_ID = "portal_book";
+
+    private final NamespacedKey key;
+    private final ItemStack item;
+    private final ShapedRecipe recipe;
+
+    public PortalBook(Plugin plugin) {
+        this.key = new NamespacedKey(plugin, KEY_ID);
+        this.item = ItemBuilder.of(Material.BOOK)
+                .name(MoreItems.getInstance().getLang().get("items.portalBook.name"))
+                .lore(Collections.singletonList(MoreItems.getInstance().getLang().get("items.portalBook.description")))
+                .persistentData(key, PersistentDataType.STRING, "pbook")
+                .build();
+
+        this.recipe = new ShapedRecipe(key, item);
+        recipe.shape(" E ", "EBE", " E ");
+        recipe.setIngredient('E', Material.ENDER_PEARL);
+        recipe.setIngredient('B', Material.BOOK);
+    }
+
+    @Override
+    public NamespacedKey getKey() {
+        return key;
+    }
+
+    @Override
+    public ItemStack getItem() {
+        return item.clone();
+    }
+
+    @Override
+    public ShapedRecipe getRecipe() {
+        return recipe;
+    }
+}

--- a/src/main/java/fr/jachou/moreItems/items/SelectiveDynamite.java
+++ b/src/main/java/fr/jachou/moreItems/items/SelectiveDynamite.java
@@ -1,0 +1,53 @@
+package fr.jachou.moreItems.items;
+
+import fr.jachou.moreItems.MoreItems;
+import fr.jachou.moreItems.utils.ItemBuilder;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.Plugin;
+
+import java.util.Collections;
+
+/**
+ * Dynamite that only breaks a selected block type.
+ */
+public class SelectiveDynamite implements CustomItem {
+    public static final String KEY_ID = "selective_dynamite";
+
+    private final NamespacedKey key;
+    private final ItemStack item;
+    private final ShapedRecipe recipe;
+
+    public SelectiveDynamite(Plugin plugin) {
+        this.key = new NamespacedKey(plugin, KEY_ID);
+        this.item = ItemBuilder.of(Material.TNT)
+                .name(MoreItems.getInstance().getLang().get("items.selectiveDynamite.name"))
+                .lore(Collections.singletonList(MoreItems.getInstance().getLang().get("items.selectiveDynamite.description")))
+                .persistentData(key, PersistentDataType.STRING, "sdyna")
+                .build();
+
+        this.recipe = new ShapedRecipe(key, item);
+        recipe.shape(" S ", "TFT", " S ");
+        recipe.setIngredient('S', Material.SAND);
+        recipe.setIngredient('T', Material.TNT);
+        recipe.setIngredient('F', Material.FLINT_AND_STEEL);
+    }
+
+    @Override
+    public NamespacedKey getKey() {
+        return key;
+    }
+
+    @Override
+    public ItemStack getItem() {
+        return item.clone();
+    }
+
+    @Override
+    public ShapedRecipe getRecipe() {
+        return recipe;
+    }
+}

--- a/src/main/java/fr/jachou/moreItems/listeners/AlchemyBackpackListener.java
+++ b/src/main/java/fr/jachou/moreItems/listeners/AlchemyBackpackListener.java
@@ -1,0 +1,48 @@
+package fr.jachou.moreItems.listeners;
+
+import fr.jachou.moreItems.MoreItems;
+import fr.jachou.moreItems.items.AlchemyBackpack;
+import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Simple bag storing potions for each player while online.
+ */
+public class AlchemyBackpackListener implements Listener {
+
+    private final NamespacedKey key = new NamespacedKey(MoreItems.getInstance(), AlchemyBackpack.KEY_ID);
+    private final Map<UUID, Inventory> inventories = new HashMap<>();
+
+    @EventHandler
+    public void onUse(PlayerInteractEvent event) {
+        if (event.getHand() != EquipmentSlot.HAND) return;
+        ItemStack item = event.getItem();
+        if (item == null || !item.hasItemMeta() || !item.getItemMeta().getPersistentDataContainer().has(key, PersistentDataType.STRING)) return;
+        event.setCancelled(true);
+        Player player = event.getPlayer();
+        Inventory inv = inventories.computeIfAbsent(player.getUniqueId(), k -> Bukkit.createInventory(player, 9, "Alchemy Bag"));
+        player.openInventory(inv);
+    }
+
+    @EventHandler
+    public void onClose(InventoryCloseEvent event) {
+        Inventory inv = inventories.get(event.getPlayer().getUniqueId());
+        if (inv != null && inv.equals(event.getInventory())) {
+            // nothing persisted
+        }
+    }
+}

--- a/src/main/java/fr/jachou/moreItems/listeners/InvisibilityHoodListener.java
+++ b/src/main/java/fr/jachou/moreItems/listeners/InvisibilityHoodListener.java
@@ -1,0 +1,33 @@
+package fr.jachou.moreItems.listeners;
+
+import fr.jachou.moreItems.MoreItems;
+import fr.jachou.moreItems.items.InvisibilityHood;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+
+/**
+ * Grants invisibility while wearing the hood.
+ */
+public class InvisibilityHoodListener implements Listener {
+
+    private final NamespacedKey key = new NamespacedKey(MoreItems.getInstance(), InvisibilityHood.KEY_ID);
+
+    @EventHandler
+    public void onMove(PlayerMoveEvent event) {
+        Player player = event.getPlayer();
+        ItemStack helmet = player.getInventory().getHelmet();
+        boolean wearing = helmet != null && helmet.hasItemMeta() && helmet.getItemMeta().getPersistentDataContainer().has(key, PersistentDataType.STRING);
+        if (wearing) {
+            player.addPotionEffect(new PotionEffect(PotionEffectType.INVISIBILITY, 40, 0, true, false));
+        } else if (player.hasPotionEffect(PotionEffectType.INVISIBILITY)) {
+            player.removePotionEffect(PotionEffectType.INVISIBILITY);
+        }
+    }
+}

--- a/src/main/java/fr/jachou/moreItems/listeners/PickupMagnetListener.java
+++ b/src/main/java/fr/jachou/moreItems/listeners/PickupMagnetListener.java
@@ -1,0 +1,37 @@
+package fr.jachou.moreItems.listeners;
+
+import fr.jachou.moreItems.MoreItems;
+import fr.jachou.moreItems.items.PickupMagnet;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
+
+/**
+ * Collects dropped items around the player when using the magnet.
+ */
+public class PickupMagnetListener implements Listener {
+
+    private final NamespacedKey key = new NamespacedKey(MoreItems.getInstance(), PickupMagnet.KEY_ID);
+
+    @EventHandler
+    public void onUse(PlayerInteractEvent event) {
+        if (event.getHand() != EquipmentSlot.HAND) return;
+        ItemStack item = event.getItem();
+        if (item == null || !item.hasItemMeta() || !item.getItemMeta().getPersistentDataContainer().has(key, PersistentDataType.STRING)) return;
+        event.setCancelled(true);
+        Player player = event.getPlayer();
+        for (Entity ent : player.getWorld().getNearbyEntities(player.getLocation(), 5, 5, 5)) {
+            if (ent instanceof Item drop) {
+                player.getInventory().addItem(drop.getItemStack());
+                drop.remove();
+            }
+        }
+    }
+}

--- a/src/main/java/fr/jachou/moreItems/listeners/PortableAnvilListener.java
+++ b/src/main/java/fr/jachou/moreItems/listeners/PortableAnvilListener.java
@@ -1,0 +1,30 @@
+package fr.jachou.moreItems.listeners;
+
+import fr.jachou.moreItems.MoreItems;
+import fr.jachou.moreItems.items.PortableAnvil;
+import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
+
+/**
+ * Opens an anvil GUI when using the PortableAnvil.
+ */
+public class PortableAnvilListener implements Listener {
+
+    private final NamespacedKey key = new NamespacedKey(MoreItems.getInstance(), PortableAnvil.KEY_ID);
+
+    @EventHandler
+    public void onUse(PlayerInteractEvent event) {
+        if (event.getHand() != EquipmentSlot.HAND) return;
+        ItemStack item = event.getItem();
+        if (item == null || !item.hasItemMeta() || !item.getItemMeta().getPersistentDataContainer().has(key, PersistentDataType.STRING)) return;
+        event.setCancelled(true);
+        event.getPlayer().openInventory(Bukkit.createInventory(event.getPlayer(), InventoryType.ANVIL));
+    }
+}

--- a/src/main/java/fr/jachou/moreItems/listeners/PortableFurnaceListener.java
+++ b/src/main/java/fr/jachou/moreItems/listeners/PortableFurnaceListener.java
@@ -1,0 +1,30 @@
+package fr.jachou.moreItems.listeners;
+
+import fr.jachou.moreItems.MoreItems;
+import fr.jachou.moreItems.items.PortableFurnace;
+import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
+
+/**
+ * Opens a furnace GUI when using the PortableFurnace.
+ */
+public class PortableFurnaceListener implements Listener {
+
+    private final NamespacedKey key = new NamespacedKey(MoreItems.getInstance(), PortableFurnace.KEY_ID);
+
+    @EventHandler
+    public void onUse(PlayerInteractEvent event) {
+        if (event.getHand() != EquipmentSlot.HAND) return;
+        ItemStack item = event.getItem();
+        if (item == null || !item.hasItemMeta() || !item.getItemMeta().getPersistentDataContainer().has(key, PersistentDataType.STRING)) return;
+        event.setCancelled(true);
+        event.getPlayer().openInventory(Bukkit.createInventory(event.getPlayer(), InventoryType.FURNACE));
+    }
+}

--- a/src/main/java/fr/jachou/moreItems/listeners/PortalBookListener.java
+++ b/src/main/java/fr/jachou/moreItems/listeners/PortalBookListener.java
@@ -1,0 +1,45 @@
+package fr.jachou.moreItems.listeners;
+
+import fr.jachou.moreItems.MoreItems;
+import fr.jachou.moreItems.items.PortalBook;
+import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
+import org.bukkit.World;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
+
+/**
+ * Handles teleport anchors for the portal book.
+ */
+public class PortalBookListener implements Listener {
+
+    private final NamespacedKey key = new NamespacedKey(MoreItems.getInstance(), PortalBook.KEY_ID);
+
+    @EventHandler
+    public void onUse(PlayerInteractEvent event) {
+        if (event.getHand() != EquipmentSlot.HAND) return;
+        ItemStack item = event.getItem();
+        if (item == null || !item.hasItemMeta() || !item.getItemMeta().getPersistentDataContainer().has(key, PersistentDataType.STRING)) return;
+        event.setCancelled(true);
+        var container = item.getItemMeta().getPersistentDataContainer();
+        if (event.getPlayer().isSneaking() && event.getClickedBlock() != null) {
+            Location loc = event.getClickedBlock().getLocation();
+            container.set(key, PersistentDataType.STRING, loc.getWorld().getName()+","+loc.getBlockX()+","+loc.getBlockY()+","+loc.getBlockZ());
+            item.setItemMeta(item.getItemMeta());
+            return;
+        }
+        String data = container.get(key, PersistentDataType.STRING);
+        if (data == null || !data.contains(",")) return;
+        String[] parts = data.split(",");
+        World world = event.getPlayer().getServer().getWorld(parts[0]);
+        if (world == null) return;
+        int x = Integer.parseInt(parts[1]);
+        int y = Integer.parseInt(parts[2]);
+        int z = Integer.parseInt(parts[3]);
+        event.getPlayer().teleport(new Location(world, x + 0.5, y + 1, z + 0.5));
+    }
+}

--- a/src/main/java/fr/jachou/moreItems/listeners/SelectiveDynamiteListener.java
+++ b/src/main/java/fr/jachou/moreItems/listeners/SelectiveDynamiteListener.java
@@ -1,0 +1,46 @@
+package fr.jachou.moreItems.listeners;
+
+import fr.jachou.moreItems.MoreItems;
+import fr.jachou.moreItems.items.SelectiveDynamite;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.TNTPrimed;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityExplodeEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.persistence.PersistentDataType;
+
+/**
+ * Spawns TNT that only breaks selected block types.
+ */
+public class SelectiveDynamiteListener implements Listener {
+
+    private final NamespacedKey key = new NamespacedKey(MoreItems.getInstance(), SelectiveDynamite.KEY_ID);
+
+    @EventHandler
+    public void onUse(PlayerInteractEvent event) {
+        if (event.getHand() != EquipmentSlot.HAND) return;
+        ItemStack item = event.getItem();
+        if (item == null || !item.hasItemMeta() || !item.getItemMeta().getPersistentDataContainer().has(key, PersistentDataType.STRING)) return;
+        event.setCancelled(true);
+        Material target = event.getClickedBlock() != null ? event.getClickedBlock().getType() : Material.STONE;
+        Location spawn = event.getClickedBlock() != null ? event.getClickedBlock().getLocation().add(0.5, 1, 0.5) : event.getPlayer().getLocation();
+        TNTPrimed tnt = (TNTPrimed) spawn.getWorld().spawnEntity(spawn, EntityType.TNT);
+        tnt.getPersistentDataContainer().set(key, PersistentDataType.STRING, target.name());
+        if (item.getAmount() > 1) item.setAmount(item.getAmount() - 1); else event.getPlayer().getInventory().removeItem(item);
+    }
+
+    @EventHandler
+    public void onExplode(EntityExplodeEvent event) {
+        if (!(event.getEntity() instanceof TNTPrimed tnt)) return;
+        String type = tnt.getPersistentDataContainer().get(key, PersistentDataType.STRING);
+        if (type == null) return;
+        Material mat = Material.matchMaterial(type);
+        event.blockList().removeIf(b -> b.getType() != mat);
+    }
+}

--- a/src/main/java/fr/jachou/moreItems/managers/EventManager.java
+++ b/src/main/java/fr/jachou/moreItems/managers/EventManager.java
@@ -34,5 +34,12 @@ public final class EventManager {
         plugin.getServer().getPluginManager().registerEvents(new CampfireStickListener(), plugin);
         plugin.getServer().getPluginManager().registerEvents(new ReturnScrollListener(), plugin);
         plugin.getServer().getPluginManager().registerEvents(new IcePopListener(), plugin);
+        plugin.getServer().getPluginManager().registerEvents(new PickupMagnetListener(), plugin);
+        plugin.getServer().getPluginManager().registerEvents(new PortableFurnaceListener(), plugin);
+        plugin.getServer().getPluginManager().registerEvents(new PortableAnvilListener(), plugin);
+        plugin.getServer().getPluginManager().registerEvents(new InvisibilityHoodListener(), plugin);
+        plugin.getServer().getPluginManager().registerEvents(new PortalBookListener(), plugin);
+        plugin.getServer().getPluginManager().registerEvents(new AlchemyBackpackListener(), plugin);
+        plugin.getServer().getPluginManager().registerEvents(new SelectiveDynamiteListener(), plugin);
     }
 }

--- a/src/main/java/fr/jachou/moreItems/managers/ItemManager.java
+++ b/src/main/java/fr/jachou/moreItems/managers/ItemManager.java
@@ -43,6 +43,13 @@ public final class ItemManager {
         register(new CampfireStick(plugin), Category.TOOL);
         register(new ReturnScroll(plugin), Category.UTILITY);
         register(new IcePop(plugin), Category.UTILITY);
+        register(new PickupMagnet(plugin), Category.UTILITY);
+        register(new PortableFurnace(plugin), Category.UTILITY);
+        register(new PortableAnvil(plugin), Category.TOOL);
+        register(new InvisibilityHood(plugin), Category.ARMOR);
+        register(new PortalBook(plugin), Category.UTILITY);
+        register(new AlchemyBackpack(plugin), Category.UTILITY);
+        register(new SelectiveDynamite(plugin), Category.TOOL);
     }
 
     private static void register(CustomItem item, Category category) {

--- a/src/main/resources/lang/en.yml
+++ b/src/main/resources/lang/en.yml
@@ -64,6 +64,27 @@ items:
   icePop:
     name: "§bIce Pop"
     description: "§7Heals but slows you."
+  pickupMagnet:
+    name: "§ePickup Magnet"
+    description: "§7Collect nearby drops on use."
+  portableFurnace:
+    name: "§6Portable Furnace"
+    description: "§7Opens a furnace wherever you are."
+  portableAnvil:
+    name: "§7Portable Anvil"
+    description: "§7Repair items without placing an anvil."
+  invisibilityHood:
+    name: "§fInvisibility Hood"
+    description: "§7Makes you invisible while worn."
+  portalBook:
+    name: "§dPortal Book"
+    description: "§7Set an anchor with sneak-use, teleport on use."
+  alchemyBackpack:
+    name: "§5Alchemy Backpack"
+    description: "§7Small pouch to store potions."
+  selectiveDynamite:
+    name: "§cSelective Dynamite"
+    description: "§7Explodes only chosen blocks."
 categories:
   ARMOR: "§bArmor"
   WEAPON: "§cWeapons"


### PR DESCRIPTION
## Summary
- add pickup magnet and listener
- add portable furnace and anvil items
- add invisibility hood, portal book, alchemy backpack
- add selective dynamite item
- wire new items and listeners into managers
- document new items in `en.yml`

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_686c01924ce0832ea13296c225ad7424